### PR TITLE
update karma and karma-webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xhr-interceptor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "scripts": {
     "build": "babel index.es6.js --out-file index.js",
     "dev": "webpack --watch",
@@ -29,13 +29,13 @@
     "babel-core": "^5.0.8",
     "babel-loader": "^5.0.0",
     "expect": "^1.6.0",
-    "karma": "^0.12.31",
+    "karma": "^1.1.2",
     "karma-chrome-launcher": "^0.1.7",
     "karma-cli": "0.0.4",
     "karma-firefox-launcher": "^0.1.4",
     "karma-mocha": "^0.1.10",
     "karma-sourcemap-loader": "^0.3.4",
-    "karma-webpack": "^1.5.0",
+    "karma-webpack": "^1.8.0",
     "mocha": "^2.2.1",
     "webpack": "^1.7.3",
     "webpack-dev-server": "^1.8.0"

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -82,6 +82,6 @@ describe('basics', () => {
     })
 
     const response = await axios.get('/foo')
-    expect(response.data).toBe('2')
+    expect(response.data).toBe(2)
   })
 })


### PR DESCRIPTION
was seeing two issues:
1. Upgrading karma and karma-webpack fixes https://github.com/aaronshaf/xhr-interceptor/issues/9
2. I inspected [`content`](https://github.com/aaronshaf/xhr-interceptor/blob/master/index.es6.js#L165) as it was being passed and it was a string. But I still received the error below when running tests for [this assertion](https://github.com/aaronshaf/xhr-interceptor/blob/master/test/index.spec.js#L85). I didn't fully check but perhaps axios is manipulating the response?

```
Chrome 52.0.2743 (Mac OS X 10.11.5) basics stacked routes as middleware FAILED
    Error: Expected 2 to be '2'
        at assert (test/index.spec.js:4544:10)
        at Expectation.toBe (test/index.spec.js:1981:29)
        at Context.callee$1$0$ (test/index.spec.js:229:52)
        at tryCatch (node_modules/babel-core/browser-polyfill.js:3814:40)
        at GeneratorFunctionPrototype.invoke [as _invoke] (node_modules/babel-core/browser-polyfill.js:4081:22)
        at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (node_modules/babel-core/browser-polyfill.js:3847:21)
        at GeneratorFunctionPrototype.invoke (node_modules/babel-core/browser-polyfill.js:3889:37)
.
```
